### PR TITLE
Fix typo in index.html

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -58,7 +58,7 @@ test( "hello test", function() {
     </ul>
     <h3>History</h3>
     <p>
-        QUnit was originally developed by John Resig as part of jQuery. In 2008 it got its own home, name and API documentation, allowing others to use it for their unit testing as well. At the time it still depended on jQuery. A rewrite in 2009 fixed that, now QUnit runs completely standalone.
+        QUnit was originally developed by John Resig as part of jQuery. In 2008 it got its own home, name and API documentation, allowing others to use it for their unit testing as well. At the time it still depended on jQuery. A rewrite in 2009 fixed that, and now QUnit runs completely standalone.
     </p>
     <p>
       QUnit's assertion methods follow the <a href="http://wiki.commonjs.org/wiki/Unit_Testing/1.0">CommonJS Unit Testing</a> specification, which was to some degree influenced by QUnit.


### PR DESCRIPTION
Someone please push to http://qunitjs.com/. The index.html there is even older, with the "dependended" typo.
