### PR TITLE
move final paragraphs into eight column section

### DIFF
--- a/pages/cookbook.html
+++ b/pages/cookbook.html
@@ -479,8 +479,7 @@ test( "test with setup and teardown", function() {
 		If you want to read more on unit testing JavaScript (not specific to QUnit), check out the book <a href="http://tddjs.com/" class="external text" title="http://tddjs.com/">Test-Driven JavaScript Development</a>.
 	</p>
 
+	<p>
+		<em>*This section was first published, under a non-exclusive license, as the last chapter in the jQuery Cookbook, authored by Scott González and Jörn Zaefferer. As QUnit changed since the book was printed, this version is more up-to-date.</em>
+	</p>
 </div>
-
-<p>
-	<em>*This section was first published, under a non-exclusive license, as the last chapter in the jQuery Cookbook, authored by Scott González and Jörn Zaefferer. As QUnit changed since the book was printed, this version is more up-to-date.</em>
-</p>

--- a/pages/intro.html
+++ b/pages/intro.html
@@ -189,6 +189,5 @@
 	<p>Testing JavaScript code is not just a matter of using some test runner and writing a few tests; it usually requires some heavy structural changes when applied to code that has been tested only manually before. We’ve walked through an example of how to change the code structure of an existing module to run some tests using an ad-hoc testing framework, then replacing that with a more full-featured framework to get useful visual results.</p>
 
 	<p>QUnit itself has a lot more to offer, with specific support for testing asynchronous code such as timeouts, AJAX and events. Its visual test runner helps to debug code by making it easy to rerun specific tests and by providing stack traces for failed assertions and caught exceptions. For further reading, check out the <a href="/cookbook">QUnit Cookbook</a>.</p>
+	<p><em><a href="http://coding.smashingmagazine.com/2012/06/27/introduction-to-javascript-unit-testing/">Originally published on Smashing Magazine, June 2012</a></em></p>
 </div>
-
-<p><em><a href="http://coding.smashingmagazine.com/2012/06/27/introduction-to-javascript-unit-testing/">Originally published on Smashing Magazine, June 2012</a></em></p>


### PR DESCRIPTION
Currently, the cookbook and intro pages have final paragraphs that are much wider than the previous content, and have no padding on the left.  Currently, it looks like:

![Screen Shot 2013-01-24 at 11 46 01 AM](https://f.cloud.github.com/assets/475621/94267/92f2a0cc-6645-11e2-88d4-42d42c47bd02.png)

I've moved these into the previous sections, and now this looks like:

![Screen Shot 2013-01-24 at 11 46 41 AM](https://f.cloud.github.com/assets/475621/94272/b6d90f44-6645-11e2-8930-dcc67c5cacd4.png)
