### PR TITLE
Changed 'suite' to 'framework' in the description

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -5,7 +5,7 @@
 <div class="six columns">
 	<h2>What is QUnit?</h2>
 	<p class="blurb">
-		QUnit is a powerful, easy-to-use JavaScript unit test suite. It's used by the jQuery, jQuery UI and jQuery Mobile projects and is capable of testing any generic JavaScript code, <a href="https://github.com/jquery/qunit/tree/master/test">including itself</a>!
+		QUnit is a powerful, easy-to-use JavaScript unit testing framework. It's used by the jQuery, jQuery UI and jQuery Mobile projects and is capable of testing any generic JavaScript code, <a href="https://github.com/jquery/qunit/tree/master/test">including itself</a>!
 	</p>
 
 	<h2>Getting Started</h2>


### PR DESCRIPTION
Referring to QUnit as a suite is really confusing because:
 1. We often refer to test modules as 'test suites'/'testsuites' (inconsistent on the site, unfortunately)
 2. The QUnit composite addon also adds the concept of 'suites' when referring to loading hierarchically nested test pages
