### PR TITLE
Added link to qunit-once plugin

### DIFF
--- a/pages/plugins.html
+++ b/pages/plugins.html
@@ -64,7 +64,7 @@
 	</li>
 	<li>
 		<a href="https://github.com/bahmutov/qunit-once">qunit-once</a> - A QUnit plugin
-		that adds <strong>setupOne</strong> and <strong>teardownOnce</strong> to module's config.
+		that adds <code>setupOnce</code> and <code>teardownOnce</code> to module's config.
 	</li>
 </ul>
 


### PR DESCRIPTION
[qunit-once](https://github.com/bahmutov/qunit-once) makes it easy to run a method once at the start of a module, and once after. After including qunit-once you get two additional functions

``` js
QUnit.module('Example', {
  setupOnce: function () {
    // runs once before anything else in the module
  },
  setup: function () {
    // runs before each unit test
  },
  teardown: function () {
    // runs after EACH unit test in this module
  },
  teardownOnce: function () {
    // runs once after all unit tests finished (including teardown)
  }
});
```
