### PR TITLE
Remove deprecated 'expected' arg from cookbook asyncTest

### DIFF
--- a/pages/cookbook.html
+++ b/pages/cookbook.html
@@ -247,7 +247,9 @@ asyncTest( "asynchronous test: one second later!", function() {
 
 	<pre><code>
 
-asyncTest( "asynchronous test: video ready to play", 1, function() {
+asyncTest( "asynchronous test: video ready to play", function() {
+	expect( 1 );
+	
 	var $video = $( "video" );
 
 	$video.on( "canplaythrough", function() {


### PR DESCRIPTION
Documentation of deprecation: https://api.qunitjs.com/asyncTest/

Also note that the same example appears at the bottom of the above page (right below the notice of deprecation), so it should be fixed there too but I couldn't find that page in this repo.
