### PR TITLE
added link to qunit-inject dependency injection plugin

### DIFF
--- a/pages/plugins.html
+++ b/pages/plugins.html
@@ -15,6 +15,8 @@
 	<li><a href="https://github.com/JamesMGreene/qunit-assert-canvas">Canvas</a> - A QUnit plugin for asserting individual pixel values within a Canvas element.</li>
 	<li><a href="https://github.com/bahmutov/qunit-promises">qunit-promises</a> - A QUnit plugin for asserting results of promises.</li>
 	<li><a href="https://github.com/bahmutov/qunit-once">qunit-once</a> - A QUnit plugin that adds <code>setupOnce</code> and <code>teardownOnce</code> to module's config.</li>
+	<li><a href="https://github.com/bahmutov/qunit-inject">qunit-inject</a> - A QUnit plugin that allows dependency injection from a module's
+	config object into individual unit tests</li>
 </ul>
 
 <h2>Mocking Tools</h2>


### PR DESCRIPTION
Added link to [qunit-inject](https://github.com/bahmutov/qunit-inject), which allows things like

``` js
QUnit.module('QUnit.assert tests WITH injection', {
  a: 42,
  b: 1
});
QUnit.test('injection sandwich', function (b, assert, a) {
  assert.equal(a, 42, 'assert works');
  assert.equal(b, 1, 'b value');
});
```
