### PR TITLE
Added link to qunit-helpful

### DIFF
--- a/pages/plugins.html
+++ b/pages/plugins.html
@@ -17,6 +17,7 @@
 	<li><a href="https://github.com/bahmutov/qunit-once">qunit-once</a> - A QUnit plugin that adds <code>setupOnce</code> and <code>teardownOnce</code> to module's config.</li>
 	<li><a href="https://github.com/bahmutov/qunit-inject">qunit-inject</a> - A QUnit plugin that allows dependency injection from a module's
 	config object into individual unit tests</li>
+	<li><a href="https://github.com/bahmutov/qunit-helpful">qunit-helpful</a> - A QUnit plugin that shows the failed expression in assertion message.</li>
 </ul>
 
 <h2>Mocking Tools</h2>


### PR DESCRIPTION
Added link to [qunit-helpful](https://github.com/bahmutov/qunit-helpful) - adds the actual expression that failed the assertion to the error message

``` js
// QUnit test with failing assertion
QUnit.test('simple test', function () {
  ok(2 + 2 === 5);
});

// output
  Errors:
    Module: global Test: simple test

// load qunit-helpful.js before tests, same test
// output
  Errors: ok [2 + 2 === 5]
    Module: global Test: simple test
```
