### PR TITLE
Cleanup: Update last instance of 'add-ons' to 'plugins'

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -58,7 +58,7 @@ QUnit.test( "hello test", function( assert ) {
 	<ul>
 		<li>Check out the <a href="http://api.qunitjs.com/">API documentation</a> or the <a href="/cookbook">Cookbook</a> to learn how to use QUnit</li>
 		<li>To see more examples, check out the unit tests of <a href="https://github.com/jquery/jquery/tree/master/test/unit">jQuery</a>, <a href="https://github.com/jquery/jquery-ui/tree/master/tests/unit">jQuery UI</a> or the <a href="https://github.com/jzaefferer/jquery-validation/tree/master/test">jQuery Validation Plugin</a>.</li>
-		<li>For custom assertions, reporters and themes, check out <a href="/addons/">official and third-party add-ons</a></li>
+		<li>For custom assertions, reporters and themes, check out <a href="/plugins/">official and third-party plugins</a></li>
 		<li>Please post to the <a href="http://forum.jquery.com/qunit-and-testing">QUnit and testing forum</a> for anything related to QUnit or testing in general.</li>
 		<li>For announcements, follow <a href="http://twitter.com/qunitjs">@qunitjs</a></li>
 	</ul>


### PR DESCRIPTION
We missed one final instance of the word "add-ons"/"addons" on the QUnit website that should've been updated to "plugins".

Ref jquery/qunit#447
