### PR TITLE
"Cookbook" docs: Change "equal" to "assert.equal" in example

### DIFF
--- a/pages/cookbook.html
+++ b/pages/cookbook.html
@@ -341,7 +341,7 @@ QUnit.test( "Appends a div", function( assert ) {
 	var $fixture = $( "#qunit-fixture" );
 
 	$fixture.append( "&lt;div>hello!&lt;/div>" );
-	equal( $( "div", $fixture ).length, 1, "div added successfully!" );
+	assert.equal( $( "div", $fixture ).length, 1, "div added successfully!" );
 });
 
 QUnit.test( "Appends a span", function( assert ) {


### PR DESCRIPTION
In Cookbook example, global "equal" method appears to be typo in
relation to more prevalent "assert.equal" usage in Cookbook. Comments
in qunit-1.15.0.js source also indicate global "equal" is "deprecated"
and remains only for "backwards compatibility."

Ref #228
