### PR TITLE
Cookbook update

### DIFF
--- a/pages/cookbook.html
+++ b/pages/cookbook.html
@@ -14,7 +14,6 @@
 		<li><a href="#grouping-tests">Grouping Tests</a></li>
 		<li><a href="#custom-assertions">Custom Assertions</a></li>
 		<li><a href="#efficient-development">Efficient Development</a></li>
-		<li><a href="#more-tutorials">More Tutorials</a></li>
 	</ul>
 </div>
 
@@ -211,33 +210,17 @@ QUnit.test( "a test", function( assert ) {
 	</p>
 	<h3 class="title" id="solution-161">Solution</h3>
 	<p>
-		For every asynchronous operation in your <code class="literal">QUnit.test()</code> callback, use <code class="literal">assert.async()</code> to request a unique resolution callback to invoke when that asynchronous operation completes so that the test execution may resume:
+		For every asynchronous operation in your <code class="literal">QUnit.test()</code> callback, use <code class="literal">assert.async()</code>, which returns a "done" function that should be called when the operation has completed.
 	</p>
 	<pre><code>
-QUnit.test( "asynchronous test: one second later!", function( assert ) {
+QUnit.test( "asynchronous test: async input focus", function( assert ) {
 	var done = assert.async();
+	var input = $( "#test-input" ).focus();
 	setTimeout(function() {
-		assert.ok( true, "Passed and ready to resume!" );
-		done();
-	}, 1000 );
-});
-</code></pre>
-	<p>
-		Practical Example:
-	</p>
-
-	<pre><code>
-QUnit.test( "asynchronous test: video ready to play", function( assert ) {
-	var done = assert.async();
-
-	var $video = $( "video" );
-
-	$video.on( "canplaythrough", function() {
-		assert.ok( true, "video has loaded and is ready to play" );
+		assert.equal( document.activeElement, input[0], "Input was focused" );
 		done();
 	});
 });
-
 </code></pre>
 
 	<h2 class="title" id="testing-user-actions">Testing User Actions</h2>
@@ -256,16 +239,12 @@ QUnit.test( "asynchronous test: video ready to play", function( assert ) {
 
 	<pre><code>
 function KeyLogger( target ) {
-	if ( !(this instanceof KeyLogger) ) {
-		return new KeyLogger( target );
-	}
 	this.target = target;
 	this.log = [];
 
-	var self = this;
-
+	var that = this;
 	this.target.off( "keydown" ).on( "keydown", function( event ) {
-		self.log.push( event.keyCode );
+		that.log.push( event.keyCode );
 	});
 }
 </code></pre>
@@ -276,33 +255,27 @@ function KeyLogger( target ) {
 
 	<pre><code>
 QUnit.test( "keylogger api behavior", function( assert ) {
+	var doc = $( document ),
+		keys = new KeyLogger( doc );
 
-	var event,
-			$doc = $( document ),
-			keys = KeyLogger( $doc );
+	// Trigger the key event
+	doc.trigger( $.Event( "keydown", { keyCode: 9 } ) );
 
-	// trigger event
-	event = $.Event( "keydown" );
-	event.keyCode = 9;
-	$doc.trigger( event );
-
-	// verify expected behavior
-	assert.equal( keys.log.length, 1, "a key was logged" );
-	assert.equal( keys.log[ 0 ], 9, "correct key was logged" );
-
+	// Verify expected behavior
+	assert.deepEqual( keys.log, [ 9 ], "correct key was logged" );
 });</code></pre>
 
 	<h3 class="title" id="discussion-id169">Discussion</h3>
 	<p>
-		If your event handler doesn't rely on any specific properties of the event, you can just call <code class="literal">.trigger(eventType)</code>. However, if your event handler does rely on specific properties of the event, you will need to create an event object using <code class="literal">$.Event</code> and set the necessary properties, as shown previously.</p><p>It's also important to trigger all relevant events for complex behaviors such as dragging, which is comprised of mousedown, at least one mousemove, and a mouseup. Keep in mind that even some events that seem simple are actually compound; e.g., a click is really a mousedown, mouseup, and then click. Whether you actually need to trigger all three of these depends on the code under test. Triggering a click works for most cases.
+		If your event handler doesn't rely on any specific properties of the event, you can just call <code class="literal">.trigger( eventType )</code>. However, if your event handler does rely on specific properties of the event, you will need to create an event object using <code class="literal">$.Event</code> with the necessary properties, as shown previously.</p><p>It's also important to trigger all relevant events for complex behaviors such as dragging, which is comprised of mousedown, at least one mousemove, and a mouseup. Keep in mind that even some events that seem simple are actually compound; e.g., a click is really a mousedown, mouseup, and then click. Whether you actually need to trigger all three of these depends on the code under test. Triggering a click works for most cases.
 	</p>
 	<p>
 		If thats not enough, you have a few framework options that help simulating user events:
 	</p>
 	<ul>
 		<li><a href="https://github.com/bitovi/syn">syn</a> "is a synthetic event library that pretty much handles typing, clicking, moving, and dragging exactly how a real user would perform those actions". Used by FuncUnit, which is based on QUnit, for functional testing of web applications.</li>
-		<li><a href="http://tinymce.ephox.com/jsrobot">JSRobot</a> - "A testing utility for web-apps that can generate real keystrokes rather than simply simulating the JavaScript event firing. This allows the keystroke to trigger the built-in browser behaviour which isn't otherwise possible."</li>
-		<li><a href="http://dojotoolkit.org/reference-guide/1.8/util/dohrobot.html">DOH Robot</a> "provides an API that enables testers to automate their UI tests using real, cross-platform, system-level input events". This gets you the closest to "real" browser events, but uses Java applets for that.</li>
+		<li><a href="https://github.com/ephox/JSRobot">JSRobot</a> - "A testing utility for web-apps that can generate real keystrokes rather than simply simulating the JavaScript event firing. This allows the keystroke to trigger the built-in browser behaviour which isn't otherwise possible."</li>
+		<li><a href="http://dojotoolkit.org/reference-guide/1.10/util/dohrobot.html">DOH Robot</a> "provides an API that enables testers to automate their UI tests using real, cross-platform, system-level input events". This gets you the closest to "real" browser events, but uses Java applets for that.</li>
 		<li><a href="https://github.com/gtramontina/keyvent.js">keyvent.js</a> - "Keyboard events simulator."</li>
 	</ul>
 
@@ -315,13 +288,13 @@ QUnit.test( "keylogger api behavior", function( assert ) {
 
 	<pre><code>
 QUnit.test( "2 asserts", function( assert ) {
-	var $fixture = $( "#qunit-fixture" );
+	var fixture = $( "#qunit-fixture" );
 
-	$fixture.append( "&lt;div>hello!&lt;/div>" );
-	assert.equal( $( "div", $fixture ).length, 1, "div added successfully!" );
+	fixture.append( "&lt;div>hello!&lt;/div>" );
+	assert.equal( $( "div", fixture ).length, 1, "div added successfully!" );
 
-	$fixture.append( "&lt;span>hello!&lt;/span>" );
-	assert.equal( $( "span", $fixture ).length, 1, "span added successfully!" );
+	fixture.append( "&lt;span>hello!&lt;/span>" );
+	assert.equal( $( "span", fixture ).length, 1, "span added successfully!" );
 });
 </code></pre>
 
@@ -336,17 +309,17 @@ QUnit.test( "2 asserts", function( assert ) {
 	<pre><code>
 
 QUnit.test( "Appends a div", function( assert ) {
-	var $fixture = $( "#qunit-fixture" );
+	var fixture = $( "#qunit-fixture" );
 
-	$fixture.append( "&lt;div>hello!&lt;/div>" );
-	assert.equal( $( "div", $fixture ).length, 1, "div added successfully!" );
+	fixture.append( "&lt;div>hello!&lt;/div>" );
+	assert.equal( $( "div", fixture ).length, 1, "div added successfully!" );
 });
 
 QUnit.test( "Appends a span", function( assert ) {
-	var $fixture = $( "#qunit-fixture" );
+	var fixture = $( "#qunit-fixture" );
 
-	$fixture.append("&lt;span>hello!&lt;/span>" );
-	assert.equal( $( "span", $fixture ).length, 1, "span added successfully!" );
+	fixture.append("&lt;span>hello!&lt;/span>" );
+	assert.equal( $( "span", fixture ).length, 1, "span added successfully!" );
 });
 </code></pre>
 	<p>
@@ -493,22 +466,7 @@ QUnit.test("retrieving object keys", function( assert ) {
 	<p>
 		Running all tests within a module works pretty much the same way, except that you choose the module to run using the select at the top right. It'll set a "module=N" query string, where "N" is the encoded name of the module, for example "?module=testEnvironment%20with%20object".
 	</p>
-
-	<h2 class="title" id="more-tutorials">Further tutorials</h2>
-	<ul>
-		<li><a href="http://www.swift-lizard.com/2009/11/24/test-driven-development-with-jquery-qunit/" class="external text" title="http://www.swift-lizard.com/2009/11/24/test-driven-development-with-jquery-qunit/">A short QUnit introduction in english</a></li>
-		<li><a href="http://www.aspnetzone.de/blogs/robertobez/archive/2009/12/02/jQuery-javascript-qunit-unit-test-framework.aspx" class="external text" title="http://www.aspnetzone.de/blogs/robertobez/archive/2009/12/02/jQuery-javascript-qunit-unit-test-framework.aspx">A short QUnit introduction in german</a></li>
-		<li><a href="http://net.tutsplus.com/tutorials/javascript-ajax/how-to-test-your-javascript-code-with-qunit/" class="external text" title="http://net.tutsplus.com/tutorials/javascript-ajax/how-to-test-your-javascript-code-with-qunit/">Nettuts on Testing with QUnit</a></li>
-		<li><a href="http://twoguysarguing.wordpress.com/2010/11/02/make-javascript-tests-part-of-your-build-qunit-rhino/" class="external text" title="http://twoguysarguing.wordpress.com/2010/11/02/make-javascript-tests-part-of-your-build-qunit-rhino/">Running QUnit tests with Rhino</a></li>
-		<li><a href="http://martinfowler.com/articles/nonDeterminism.html" class="external text" title="http://martinfowler.com/articles/nonDeterminism.html">Martin Fowler on Eradicating Non-Determinism in Tests. Not QUnit specific, but very useful advice and a lot of it applies to JavaScript</a></li>
-		<li><a href="http://msdn.microsoft.com/en-us/scriptjunkie/gg749824.aspx" class="external text" title="http://msdn.microsoft.com/en-us/scriptjunkie/gg749824.aspx">ScriptJunkie article on Automating JavaScript Testing with QUnit</a></li>
-		<li><a href="http://benalman.com/talks/unit-testing-qunit.html">Ben Alman's slides on "Unit Testing with QUnit"</a></li>
-	</ul>
 	<p>
-		If you want to read more on unit testing JavaScript (not specific to QUnit), check out the book <a href="http://tddjs.com/" class="external text" title="http://tddjs.com/">Test-Driven JavaScript Development</a>.
-	</p>
-
-	<p>
-		<em>*This section was first published, under a non-exclusive license, as the last chapter in the jQuery Cookbook, authored by Scott González and Jörn Zaefferer. As QUnit changed since the book was printed, this version is more up-to-date.</em>
+		<em>*This page was first published, under a non-exclusive license, as a chapter in the jQuery Cookbook, authored by Scott González and Jörn Zaefferer. As QUnit changed since the book was printed, this version is more up-to-date.</em>
 	</p>
 </div>


### PR DESCRIPTION
Builds on top of #84, editing some descriptions, but mostly fixing old stuff.

From the commit message:
- Rewords the async() description
- Replaces both async() examples with one actual practical example
- simplifies the keylogger example
- updates links to external sites
- removes further tutorials, since they're all outdated
- removes book reference, will put in footer
