### PR TITLE
Fixed some broken links

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -47,7 +47,7 @@ QUnit.test( "hello test", function( assert ) {
 			<li><a href="https://npmjs.org/package/qunitjs">NPM</a>: <input class="copyable" value="npm install --save-dev qunitjs" readonly></li>
 			<li>Bower: <input class="copyable" value="bower install --save-dev qunit" readonly></li>
 		</ul>
-		<p>To test the latest features and bug fixes to QUnit, a version automatically generated from the latest commit to the <a href="http://github.com/jquery/qunit" target="_blank">QUnit Git repository</a> is also available for use.</p>
+		<p>To test the latest features and bug fixes to QUnit, a version automatically generated from the latest commit to the <a href="https://github.com/jquery/qunit" target="_blank">QUnit Git repository</a> is also available for use.</p>
 		<ul>
 			<li><a href="http://code.jquery.com/qunit/qunit-git.js">qunit-git.js</a></li>
 			<li><a href="http://code.jquery.com/qunit/qunit-git.css">qunit-git.css</a></li>
@@ -56,17 +56,17 @@ QUnit.test( "hello test", function( assert ) {
 
 	<h3>Learn More</h3>
 	<ul>
-		<li>Check out the <a href="http://api.qunitjs.com/">API documentation</a> or the <a href="/cookbook">Cookbook</a> to learn how to use QUnit</li>
+		<li>Check out the <a href="http://api.qunitjs.com/">API documentation</a> or the <a href="/cookbook/">Cookbook</a> to learn how to use QUnit</li>
 		<li>To see more examples, check out the unit tests of <a href="https://github.com/jquery/jquery/tree/master/test/unit">jQuery</a>, <a href="https://github.com/jquery/jquery-ui/tree/master/tests/unit">jQuery UI</a> or the <a href="https://github.com/jzaefferer/jquery-validation/tree/master/test">jQuery Validation Plugin</a>.</li>
 		<li>For custom assertions, reporters and themes, check out <a href="/plugins/">official and third-party plugins</a></li>
 		<li>Please post to the <a href="http://forum.jquery.com/qunit-and-testing">QUnit and testing forum</a> for anything related to QUnit or testing in general.</li>
-		<li>For announcements, follow <a href="http://twitter.com/qunitjs">@qunitjs</a></li>
+		<li>For announcements, follow <a href="https://twitter.com/qunitjs">@qunitjs</a></li>
 	</ul>
 
 	<h3>Get Involved</h3>
 	<ul>
-		<li>The code is located at: <a href="http://github.com/jquery/qunit">http://github.com/jquery/qunit</a></li>
-		<li>The code for this site is <a href="http://github.com/jquery/qunitjs.com">also on GitHub</a>, with the <a href="http://github.com/jquery/api.qunitjs.com">API pages in a separate repository</a>.</li>
+		<li>The code is located at: <a href="https://github.com/jquery/qunit">https://github.com/jquery/qunit</a></li>
+		<li>The code for this site is <a href="https://github.com/jquery/qunitjs.com">also on GitHub</a>, with the <a href="https://github.com/jquery/api.qunitjs.com">API pages in a separate repository</a>.</li>
 		<li>Find the QUnit team in <a href="http://irc.jquery.org/">#jquery-dev on Freenode</a>.
 	</ul>
 

--- a/pages/intro.html
+++ b/pages/intro.html
@@ -189,6 +189,6 @@
 
 	<p>Testing JavaScript code is not just a matter of using some test runner and writing a few tests; it usually requires some heavy structural changes when applied to code that has been tested only manually before. We’ve walked through an example of how to change the code structure of an existing module to run some tests using an ad-hoc testing framework, then replacing that with a more full-featured framework to get useful visual results.</p>
 
-	<p>QUnit itself has a lot more to offer, with specific support for testing asynchronous code such as timeouts, AJAX and events. Its visual test runner helps to debug code by making it easy to rerun specific tests and by providing stack traces for failed assertions and caught exceptions. For further reading, check out the <a href="/cookbook">QUnit Cookbook</a>.</p>
+	<p>QUnit itself has a lot more to offer, with specific support for testing asynchronous code such as timeouts, AJAX and events. Its visual test runner helps to debug code by making it easy to rerun specific tests and by providing stack traces for failed assertions and caught exceptions. For further reading, check out the <a href="/cookbook/">QUnit Cookbook</a>.</p>
 	<p><em><a href="http://coding.smashingmagazine.com/2012/06/27/introduction-to-javascript-unit-testing/">Originally published on Smashing Magazine, June 2012</a></em></p>
 </div>

--- a/pages/plugins.html
+++ b/pages/plugins.html
@@ -6,7 +6,7 @@
 <h2>API Extensions</h2>
 <p>These plugins provide custom assertions or a complete new interface to use QUnit.</p>
 <ul>
-	<li><a href="http://github.com/joshuaclayton/specit">SpecIt A QUnit-based API for bdd-style testing</a></li>
+	<li><a href="https://github.com/joshuaclayton/specit">SpecIt A QUnit-based API for bdd-style testing</a></li>
 	<li><a href="https://github.com/mmonteleone/pavlov">Pavlov - extends QUnit with a rich, higher-level, Behavioral API</a>
 	<li><a href="https://github.com/AStepaniuk/qunit-parameterize">Parameterize</a> - A QUnit plugin For Running Parameterized Tests</li>
 	<li><a href="https://github.com/JamesMGreene/qunit-assert-html">HTML</a> - A QUnit plugin for assertion methods to compare two HTML strings for equality after a rigorous normalization process.</li>
@@ -25,7 +25,7 @@
 <h2>Mocking Tools</h2>
 <p>These libraries can be used along with QUnit to mock Ajax requests, timers and more.</p>
 <ul>
-	<li><a href="http://github.com/appendto/jquery-mockjax">jQuery-Mockjax - Interface to mock ajax requests and responses</a></li>
+	<li><a href="https://github.com/appendto/jquery-mockjax">jQuery-Mockjax - Interface to mock ajax requests and responses</a></li>
 	<li><a href="http://cjohansen.no/en/javascript/using_sinon_js_with_qunit">Sinon.js integration with QUnit</a></li>
 	<li><a href="http://dexterjs.com">DexterJS - a test helper to mock functions and the XHR object.</a></li>
 </ul>
@@ -37,7 +37,7 @@
 	<li><a href="https://github.com/JamesMGreene/qunit-composite">Composite</a> - bundle multiple test suites into a single file, running them in an <code>iframe</code></li>
 	<li><a href="https://github.com/JamesMGreene/qunit-reporter-junit">JUnit Reporter</a> - produces JUnit-style XML output for test results, for integration into tools like Jenkins</li>
 	</li>
-	<li><a href="http://github.com/mkrisher/qunit_for_rails">Rails plugin for QUnit integration</a></li>
+	<li><a href="https://github.com/mkrisher/qunit_for_rails">Rails plugin for QUnit integration</a></li>
 	<li><a href="https://github.com/jivesoftware/QUnitTestRunnerPlugin">QUnit testrunner plugin for JsTestDriver</a></li>
 	<li><a href="http://drupal.org/project/qunit">Drupal module for QUnit</a></li>
 	<li><a href="https://github.com/jdalton/qunit-extras">QUnit Extras</a> - Extends QUnit with extra features and CLI support</li>

--- a/pages/upgrade-guide-2.x.md
+++ b/pages/upgrade-guide-2.x.md
@@ -280,7 +280,7 @@ QUnit.test( "refresh, after replaceState", function( assert ) {
 
 ### Replace `QUnit.jsDump` with `QUnit.dump`
 
-Originally `jsDump` was a standalone library imported into QUnit. It has since evolved further within the library. To reflect that, the property was renamed to [`QUnit.dump.parse`](http://api.qunitjs.com/QUnit.dump/). This should only affect custom reporter code, not regular testsuites.
+Originally `jsDump` was a standalone library imported into QUnit. It has since evolved further within the library. To reflect that, the property was renamed to [`QUnit.dump.parse`](http://api.qunitjs.com/QUnit.dump.parse/). This should only affect custom reporter code, not regular testsuites.
 
 Before:
 


### PR DESCRIPTION
Fixed some broken links reported by [Jenkins](http://jenkins.jquery.com/view/Websites/job/stage.qunitjs.com/lastBuild/console)

@arschmitz We'll need to ignore some links. Apparently, spider attempts to crawl the test links found on the code sniplet here http://stage.qunitjs.com/intro/.  We'll need to ignore the following links

- http://stage.qunitjs.com/2008/01/blah/57/
- http://stage.qunitjs.com/john/