### PR TITLE
Fixed url problem in example-index

### DIFF
--- a/resources/example-cookbook-1-basics.html
+++ b/resources/example-cookbook-1-basics.html
@@ -8,7 +8,7 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
-  <script src="//code.jquery.com/qunit/qunit-1.22.0.js"></script>
+  <script src="https://code.jquery.com/qunit/qunit-1.22.0.js"></script>
   <script>
     QUnit.test( "a basic test example", function( assert ) {
       var value = "hello";

--- a/resources/example-cookbook-noglobals.html
+++ b/resources/example-cookbook-noglobals.html
@@ -8,7 +8,7 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
-  <script src="//code.jquery.com/qunit/qunit-1.22.0.js"></script>
+  <script src="https://code.jquery.com/qunit/qunit-1.22.0.js"></script>
   <script>
   QUnit.test( "global pollution", function( assert ) {
     window.pollute = true;

--- a/resources/example-index.html
+++ b/resources/example-index.html
@@ -9,7 +9,7 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
-  <script src="//code.jquery.com/qunit/qunit-1.22.0.js"></script>
+  <script src="https://code.jquery.com/qunit/qunit-1.22.0.js"></script>
   <script src="tests.js"></script>
 </body>
 </html>

--- a/resources/intro/4-qunit-test.html
+++ b/resources/intro/4-qunit-test.html
@@ -5,7 +5,7 @@
 	<title>Refactored date examples</title>
 
 	<link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.22.0.css">
-	<script src="//code.jquery.com/qunit/qunit-1.22.0.js"></script>
+	<script src="https://code.jquery.com/qunit/qunit-1.22.0.js"></script>
 	<script src="prettydate.js"></script>
 
 	<script>

--- a/resources/intro/4b-qunit-test.html
+++ b/resources/intro/4b-qunit-test.html
@@ -5,7 +5,7 @@
 	<title>Refactored date examples</title>
 
 	<link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.22.0.css">
-	<script src="//code.jquery.com/qunit/qunit-1.22.0.js"></script>
+	<script src="https://code.jquery.com/qunit/qunit-1.22.0.js"></script>
 	<script src="prettydate.js"></script>
 
 	<script>

--- a/resources/intro/5-qunit-test-refactored.html
+++ b/resources/intro/5-qunit-test-refactored.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<title>Refactored date examples</title>
 	<link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.22.0.css">
-	<script src="//code.jquery.com/qunit/qunit-1.22.0.js"></script>
+	<script src="https://code.jquery.com/qunit/qunit-1.22.0.js"></script>
 	<script src="prettydate.js"></script>
 	<script>
 	QUnit.test("prettydate basics", function( assert ) {

--- a/resources/intro/6-qunit-dom.html
+++ b/resources/intro/6-qunit-dom.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<title>Refactored date examples</title>
 	<link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.22.0.css">
-	<script src="//code.jquery.com/qunit/qunit-1.22.0.js"></script>
+	<script src="https://code.jquery.com/qunit/qunit-1.22.0.js"></script>
 	<script src="prettydate2.js"></script>
 	<script>
 	QUnit.test("prettydate.format", function( assert ) {

--- a/resources/intro/7-qunit-dom-refactored.html
+++ b/resources/intro/7-qunit-dom-refactored.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<title>Refactored date examples</title>
 	<link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.22.0.css">
-	<script src="//code.jquery.com/qunit/qunit-1.22.0.js"></script>
+	<script src="https://code.jquery.com/qunit/qunit-1.22.0.js"></script>
 	<script src="prettydate2.js"></script>
 	<script>
 	QUnit.test("prettydate.format", function( assert ) {


### PR DESCRIPTION
Example index couldn't be copy and pasted then used due to missing file transfer protocol. It should be good to copy, paste, and go now.