### PR TITLE
Upgrade-Guide: Adding section for removed `assert.throws()` overload

### DIFF
--- a/pages/upgrade-guide-2.x.md
+++ b/pages/upgrade-guide-2.x.md
@@ -165,36 +165,6 @@ QUnit.test( "static properties", function( assert ) {
 ```
 
 
-## Modified assertion methods
-
-A few assertion methods have been modified.
-
-### Replace `assert.throws( block, string, message )` with `assert.throws( block, regexp, message )`
-
-The overload of `assert.throws()` which expected a block, error string, and assertion message has been removed and will now throw an exception. Use a regular expression instead.
-
-Before:
-
-```js
-QUnit.test( "throws", function( assert ) {
-	assert.throws(function() {
-		throw new Error("This is an error");
-	}, "This is an error", "An error should have been thrown");
-});
-```
-
-After:
-
-```js
-QUnit.test( "throws", function( assert ) {
-	assert.throws(function() {
-		throw new Error("This is an error");
-	}, /^This is an error$/, "An error should have been thrown");
-});
-```
-
-Note that in the two-argument overload `assert.throws( block, string )`, the string argument has always been interpreted as an assertion message. You do not need to change any of these assertions.
-
 ## Rename module hooks
 
 The [module hooks](http://api.qunitjs.com/QUnit.module/) `setup` and `teardown` have been renamed to `beforeEach` and `afterEach`, to make it more obvious that they run for each test within a module.
@@ -225,6 +195,36 @@ QUnit.module( "router", {
 });
 ```
 
+
+## Modified assertion methods
+
+A few assertion methods have been modified.
+
+### Replace `assert.throws( block, string, message )` with `assert.throws( block, regexp, message )`
+
+The overload of `assert.throws()` which expected a block, error string, and assertion message has been removed and will now throw an exception. Use a regular expression instead.
+
+Before:
+
+```js
+QUnit.test( "throws", function( assert ) {
+	assert.throws(function() {
+		throw new Error("This is an error");
+	}, "This is an error", "An error should have been thrown");
+});
+```
+
+After:
+
+```js
+QUnit.test( "throws", function( assert ) {
+	assert.throws(function() {
+		throw new Error("This is an error");
+	}, /^This is an error$/, "An error should have been thrown");
+});
+```
+
+Note that in the two-argument overload `assert.throws( block, string )`, the string argument has always been interpreted as an assertion message. You do not need to change any of these assertions.
 
 ## Removed and modified QUnit methods and properties
 

--- a/pages/upgrade-guide-2.x.md
+++ b/pages/upgrade-guide-2.x.md
@@ -220,7 +220,7 @@ QUnit.test( "throws", function( assert ) {
 });
 ```
 
-Note that in the two-argument overload `assert.throws( block, string )`, the string argument has always been interpreted as an assertion message instead of an expected value. You do not need to change any of these assertions.
+Note that in the two-argument overload `assert.throws( block, string )`, the string argument has always been interpreted as an assertion message instead of an expected value. You do not need to change any of these assertions. Of course, you may use the `assert.throws( block, regexp, message )` form anyway to make your assertions more precise.
 
 ## Removed and modified QUnit methods and properties
 

--- a/pages/upgrade-guide-2.x.md
+++ b/pages/upgrade-guide-2.x.md
@@ -196,11 +196,7 @@ QUnit.module( "router", {
 ```
 
 
-## Modified assertion methods
-
-A few assertion methods have been modified.
-
-### Replace `assert.throws( block, string, message )` with `assert.throws( block, regexp, message )`
+## Replace `assert.throws( block, string, message )` with `assert.throws( block, regexp, message )`
 
 The overload of `assert.throws()` which expected a block, error string, and assertion message has been removed and will now throw an exception. Use a regular expression instead.
 
@@ -224,7 +220,7 @@ QUnit.test( "throws", function( assert ) {
 });
 ```
 
-Note that in the two-argument overload `assert.throws( block, string )`, the string argument has always been interpreted as an assertion message. You do not need to change any of these assertions.
+Note that in the two-argument overload `assert.throws( block, string )`, the string argument has always been interpreted as an assertion message instead of an expected value. You do not need to change any of these assertions.
 
 ## Removed and modified QUnit methods and properties
 

--- a/pages/upgrade-guide-2.x.md
+++ b/pages/upgrade-guide-2.x.md
@@ -220,7 +220,7 @@ QUnit.test( "throws", function( assert ) {
 });
 ```
 
-Note that in the two-argument overload `assert.throws( block, string )`, the string argument has always been interpreted as an assertion message instead of an expected value. You do not need to change any of these assertions. Of course, you may use the `assert.throws( block, regexp, message )` form anyway to make your assertions more precise.
+Note that in the two-argument overload `assert.throws( block, string )`, the string argument has always been interpreted as an assertion message instead of an expected value. You do not need to change any of these assertions. Of course, you should use the `assert.throws( block, regexp, message )` form anyway to make your assertions more precise.
 
 ## Removed and modified QUnit methods and properties
 

--- a/pages/upgrade-guide-2.x.md
+++ b/pages/upgrade-guide-2.x.md
@@ -165,6 +165,36 @@ QUnit.test( "static properties", function( assert ) {
 ```
 
 
+## Modified assertion methods
+
+A few assertion methods have been modified.
+
+### Replace `assert.throws( block, string, message )` with `assert.throws( block, regexp, message )`
+
+The overload of `assert.throws()` which expected a block, error string, and assertion message has been removed and will now throw an exception. Use a regular expression instead.
+
+Before:
+
+```js
+QUnit.test( "throws", function( assert ) {
+	assert.throws(function() {
+		throw new Error("This is an error");
+	}, "This is an error", "An error should have been thrown");
+});
+```
+
+After:
+
+```js
+QUnit.test( "throws", function( assert ) {
+	assert.throws(function() {
+		throw new Error("This is an error");
+	}, /^This is an error$/, "An error should have been thrown");
+});
+```
+
+Note that in the two-argument overload `assert.throws( block, string )`, the string argument has always been interpreted as an assertion message. You do not need to change any of these assertions.
+
 ## Rename module hooks
 
 The [module hooks](http://api.qunitjs.com/QUnit.module/) `setup` and `teardown` have been renamed to `beforeEach` and `afterEach`, to make it more obvious that they run for each test within a module.

--- a/pages/upgrade-guide-2.x.md
+++ b/pages/upgrade-guide-2.x.md
@@ -208,9 +208,9 @@ Before:
 
 ```js
 QUnit.test( "throws", function( assert ) {
-	assert.throws(function() {
-		throw new Error("This is an error");
-	}, "This is an error", "An error should have been thrown");
+	assert.throws( function() {
+		throw new Error( "This is an error" );
+	}, "This is an error", "An error should have been thrown" );
 });
 ```
 
@@ -218,9 +218,9 @@ After:
 
 ```js
 QUnit.test( "throws", function( assert ) {
-	assert.throws(function() {
-		throw new Error("This is an error");
-	}, /^This is an error$/, "An error should have been thrown");
+	assert.throws( function() {
+		throw new Error( "This is an error" );
+	}, /^This is an error$/, "An error should have been thrown" );
 });
 ```
 


### PR DESCRIPTION
Please let me know if I should arrange things differently.

My rationale for the current arrangement:

1. The last section talks specifically about the `QUnit` namespace, both in the title and in the opening paragraph. This contribution is for an assertion method, which is not in the QUnit namespace.
1. For the most part, the upgrade guide seems to be arranged in order of largest impact items to least impact. Removed globals are obviously the biggest problem for anyone migrating a QUnit test suite, followed by the renamed module hooks. My belief is that changes to assertion methods come just above the `QUnit` namespace changes at this point-- the removed overload is probably not super common, but pretty much everything in the last section has to do with unusual or questionable setups or with reporters that need to be migrated.

If anything should be moved around or if the prose is wrong, let me know. Thanks!